### PR TITLE
Refactor filtering logic and add mapping for filters

### DIFF
--- a/BackEnd/Peach_ActiviGo.Services/Mapping/ActivityLocationMappingProfile.cs
+++ b/BackEnd/Peach_ActiviGo.Services/Mapping/ActivityLocationMappingProfile.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using Peach_ActiviGo.Core.Models;
+using Peach_ActiviGo.Core.Filter;
 using Peach_ActiviGo.Services.DTOs.ActivityLocationDto;
 
 namespace Peach_ActiviGo.Services.Mapping
@@ -18,6 +19,9 @@ namespace Peach_ActiviGo.Services.Mapping
             // DTO -> Model
             CreateMap<ReadActivityLocationDto, ActivityLocation>();
             CreateMap<UpdateActivityLocationDto, ActivityLocation>();
+
+            // Filter DTO -> Filter Model
+            CreateMap<ActivityLocationFilterDto, ActivityLocationFilter>();
         }
     }
 }

--- a/BackEnd/Peach_ActiviGo.Services/Services/ActivityLocationService.cs
+++ b/BackEnd/Peach_ActiviGo.Services/Services/ActivityLocationService.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using Peach_ActiviGo.Core.Filter;
 using Peach_ActiviGo.Core.Interface;
 using Peach_ActiviGo.Services.DTOs.ActivityLocationDto;
 using Peach_ActiviGo.Services.Interface;
@@ -41,16 +42,19 @@ namespace Peach_ActiviGo.Services.Services
 
         public async Task<IEnumerable<ReadActivityLocationDto>> FilterActivityLocationsAsync(ActivityLocationFilterDto filter, CancellationToken ct)
         {
-            // Mappa DTO till parametrar
+            // Mappa DTO till filter-objektet
+            var coreFilter = new ActivityLocationFilter
+            {
+                StartDate = filter.StartDate,
+                EndDate = filter.EndDate,
+                CategoryId = filter.CategoryId,
+                IsIndoor = filter.IsIndoor,
+                LocationId = filter.LocationId,
+                OnlyAvailableSlots = filter.OnlyAvailableSlots
+            };
+
             var activityLocations = await _unitOfWork.ActivityLocations
-                .FilterActivityLocations(
-                    filter.StartDate,
-                    filter.EndDate,
-                    filter.CategoryId,
-                    filter.IsIndoor,
-                    filter.LocationId,
-                    filter.OnlyAvailableSlots,
-                    ct);
+                .FilterActivityLocations(coreFilter, ct);
 
             return _mapper.Map<IEnumerable<ReadActivityLocationDto>>(activityLocations);
         }


### PR DESCRIPTION
Fixed some problem in the service-layer between ActivityLocationFilterDto & ActivityLocationFilter.

- Updated `ActivityLocationMappingProfile` to include a new mapping for `ActivityLocationFilterDto` to `ActivityLocationFilter`.
- Refactored `FilterActivityLocationsAsync` in `ActivityLocationService` to use the `ActivityLocationFilter` model, replacing individual filter parameters with an encapsulated object.
- Removed redundant parameter mapping logic and improved maintainability by leveraging the new mapping configuration.
- Added necessary namespace imports to support the changes.